### PR TITLE
Fix broken binary padding

### DIFF
--- a/scripts/1337
+++ b/scripts/1337
@@ -132,7 +132,7 @@ def main():
 		limit = 10
 		maxnick = len(max(entries.keys(), key=len))
 		for index, s in enumerate(sorted(entries, key=entries.get, reverse=True)):
-			pad = ' ' * (maxnick - len(s) - len('%d' % (index+1)) + 1)
+			pad = ' ' * (maxnick - len(s))
 			print "[%s] %s: %s%s" % (format(index+1, '04b'), s, pad, format(entries[s], '010b'))
 			if index == 9:
 				break


### PR DESCRIPTION
Remove old padding logic that misaligns the score of #10 in binary top score list.